### PR TITLE
feature/cxar-917-provide-refactored-ontologies

### DIFF
--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -72,7 +72,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Tar gzip files for veracode upload
         run: |-
-          tar -czvf ${{ matrix.variant.dir }}/target/${{ matrix.variant.name }}.tar.gz ${{ matrix.variant.dir }}/target/${{ matrix.variant.name }}.jar
+          tar -czvf ${{ matrix.variant.dir }}/target/${{ matrix.variant.name }}.tar.gz ${{ matrix.variant.dir }}/target/${{ matrix.variant.name }}-*.jar
       - name: Veracode Upload And Scan
         uses: veracode/veracode-uploadandscan-action@v1.0
         if: |

--- a/ontology/catalog-v001.xml
+++ b/ontology/catalog-v001.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <uri id="User Entered Import Resolution" name="file:common_ontology.ttl" uri="common_ontology.ttl"/>
+    <uri id="User Entered Import Resolution" name="file:core_ontology.ttl" uri="core_ontology.ttl"/>
+    <uri id="User Entered Import Resolution" name="file:vehicle_ontology.ttl" uri="vehicle_ontology.ttl"/>
+    <uri id="User Entered Import Resolution" name="file:function_ontology.ttl" uri="function_ontology.ttl"/>
+    <uri id="User Entered Import Resolution" name="file:reliability_ontology.ttl" uri="reliability_ontology.ttl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base=""/>
 </catalog>

--- a/ontology/catalog-v001.xml
+++ b/ontology/catalog-v001.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="User Entered Import Resolution" name="file:common_ontology.ttl" uri="common_ontology.ttl"/>
+    <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base=""/>
+</catalog>

--- a/ontology/common_ontology.ttl
+++ b/ontology/common_ontology.ttl
@@ -4,6 +4,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix json: <https://json-schema.org/draft/2020-12/schema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <https://schema.org/> .
@@ -11,11 +12,12 @@
 @base <https://w3id.org/catenax/ontology/common#> .
 
 <https://w3id.org/catenax/ontology/common> rdf:type owl:Ontology ;
-                                                          dc:creator "Zazralt Magic" ;
-                                                          dc:date "2023-05-23"^^xsd:date ;
-                                                          dc:description "The common ontology describes the Dataspace connectors in detail. On the one hand, this includes the information from which Catena-X business partner the connectors are deployed. On the other hand, with which contracts which assets provide the connectors."@en ;
-                                                          dc:title "Common Ontology" ;
-                                                          owl:versionInfo "0.9.1" .
+                                           dc:contributor "Oguzhan Balandi" ;
+                                           dc:creator "Zazralt Magic" ;
+                                          dc:date "2023-05-23"^^xsd:date ;
+                                          dc:description "The common ontology describes the Dataspace connectors in detail. On the one hand, this includes the information from which Catena-X business partner the connectors are deployed. On the other hand, with which contracts which assets provide the connectors."@en ;
+                                          dc:title "Common Ontology" ;
+                                          owl:versionInfo "1.9.4" .
 
 #################################################################
 #    Annotation properties
@@ -52,6 +54,9 @@ skos:example rdf:type owl:AnnotationProperty .
 ###  http://www.w3.org/2004/02/skos/core#prefLabel
 skos:prefLabel rdf:type owl:AnnotationProperty .
 
+
+###  https://json-schema.org/draft/2020-12/schema#Object
+json:Object rdf:type rdfs:Datatype .
 
 #################################################################
 #    Object Properties
@@ -140,6 +145,23 @@ cx-common:url rdf:type owl:DatatypeProperty ;
               rdfs:domain cx-common:DataspaceConnector ;
               rdfs:range xsd:anyURI .
 
+
+###  https://catena-x.net/product-knowledge/ontology/common#authenticationInformation
+cx-common:authenticationInformation rdf:type owl:DatatypeProperty ;
+              rdfs:comment "Base property for all authentication informations.";
+              rdfs:subPropertyOf owl:topDataProperty ;
+              rdfs:domain rdfs:Resource ;
+              rdfs:range xsd:string .
+
+###  https://catena-x.net/product-knowledge/ontology/common#authenticationCode
+cx-common:authenticationCode rdf:type owl:DatatypeProperty ;
+              rdfs:comment "An authentication code under which authentication information are transmitted.";
+              rdfs:subPropertyOf cx-common:authenticationInformation.
+
+###  https://catena-x.net/product-knowledge/ontology/common#authenticationKey
+cx-common:authenticationKey rdf:type owl:DatatypeProperty ;
+              rdfs:comment "An authentication key which encodes some authentication proof.";
+              rdfs:subPropertyOf cx-common:authenticationInformation.
 
 ###  https://catena-x.net/product-knowledge/ontology/common#version
 cx-common:version rdf:type owl:DatatypeProperty ;

--- a/ontology/core_ontology.ttl
+++ b/ontology/core_ontology.ttl
@@ -15,7 +15,7 @@
                                                         dc:date "2023-05-05"^^xsd:date ;
                                                         dc:description "The Catena-X core ontology contains main domain-independent classes, attributes and relations." ;
                                                         dc:title "Core Ontology" ;
-                                                        owl:versionInfo "0.9.1" .
+                                                        owl:versionInfo "1.9.4" .
 
 #################################################################
 #    Annotation properties
@@ -51,7 +51,6 @@ skos:example rdf:type owl:AnnotationProperty .
 
 ###  http://www.w3.org/2004/02/skos/core#prefLabel
 skos:prefLabel rdf:type owl:AnnotationProperty .
-
 
 #################################################################
 #    Object Properties

--- a/ontology/function_ontology.ttl
+++ b/ontology/function_ontology.ttl
@@ -1,0 +1,231 @@
+@prefix : <https://w3id.org/catenax/ontology/vfunction#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix schema: <https://schema.org/> .
+@prefix cx-common: <https://w3id.org/catenax/ontology/common#> .
+@prefix cx-fx: <https://w3id.org/catenax/ontology/function#> .
+@base <https://w3id.org/catenax/ontology/function> .
+
+<https://w3id.org/catenax/ontology/function> rdf:type owl:Ontology ;
+                                             dc:contributor "Oguzhan Balandi" ;
+                                             dc:creator "Christoph Jung" ;
+                                             dc:date "2023-06-29"^^xsd:date ;
+                                             dc:description "Ontology for function invocations." ;
+                                             dc:title "Function Ontology" ;
+                                             owl:imports <file:common_ontology.ttl>;
+                                             owl:versionInfo "1.9.4" .
+
+###  https://w3id.org/catenax/ontology/function#Function
+cx-fx:Function rdf:type owl:Class ;
+               rdfs:subClassOf cx-core:ConceptualObject ;
+               skos:altLabel "Function Definition"@en ;
+               skos:prefLabel "Function"@en .
+
+###  https://w3id.org/catenax/ontology/function#callbackAddress
+cx-fx:callbackAddress rdf:type owl:ObjectProperty ;
+                              rdfs:domain rdfs:Resource;
+                              rdfs:range rdfs:Resource;
+                              skos:example <http://localhost:8888/callback>;
+                              rdfs:comment  "Documents that a given resource exhibits a callback endpoint. The URI/IRI should resolve to some existing URL."@en ;
+                              skos:prefLabel "Callback Address"@en .
+
+###  https://w3id.org/catenax/ontology/function#supportsInvocation
+cx-fx:supportsInvocation rdf:type owl:ObjectProperty ;
+                              rdfs:domain rdfs:Resource;
+                              rdfs:range cx-fx:Function;
+                              skos:note "Documents that a given resource supports a certain function."@en ;
+                              skos:prefLabel "Function Support"@en .
+
+###  https://w3id.org/catenax/ontology/function#targetUri
+cx-fx:targetUri rdf:type owl:ObjectProperty ;
+                              rdfs:domain cx-fx:Function ;
+                              rdfs:range rdfs:Resource;
+                              skos:example <class:org.eclipse.tractusx.agents.remoting.TestFunction#test> ;
+                              skos:example <http://tiera-backend:5005/api/rul> ;
+                              skos:example <https://api.agify.io> ;
+                              rdfs:comment  "The target URI of the function should resolve to some existing service (URL)."@en ;
+                              skos:prefLabel "Target URI"@en .
+
+###  https://w3id.org/catenax/ontology/function#invocationMethod
+cx-fx:invocationMethod rdf:type owl:DatatypeProperty ;
+              rdfs:comment "Determines the invocation method of the function in case that the target service provides several possibilities."@en;
+              rdfs:subPropertyOf owl:topDataProperty ;
+              rdfs:domain cx-fx:Function ;
+              rdfs:range xsd:string;
+              skos:example "DEFAULT";
+              skos:example "GET";
+              skos:example "POST-JSON-MF";
+              skos:example "POST-JSON";
+              skos:example "POST-XML-MF";
+              skos:example "POST-XML";
+              skos:prefLabel "Invocation Method"@en .
+
+###  https://w3id.org/catenax/ontology/function#batch
+cx-fx:batch rdf:type owl:DatatypeProperty ;
+            rdfs:comment "Determines maximal batch size for function invocations. Default is '1' which means that each invocation is done separately"@en;
+            rdfs:subPropertyOf owl:topDataProperty ;
+            rdfs:domain cx-fx:Function ;
+            rdfs:range xsd:long;
+            skos:example "100"^^xsd:long;
+            skos:altLabel "Maximal Batch Size"@en;
+            skos:prefLabel "Batch Size"@en .
+
+###  https://w3id.org/catenax/ontology/function#inputProperty
+cx-fx:inputProperty rdf:type owl:DatatypeProperty ;
+            rdfs:comment "Determines a path/name in the input document under which all input arguments are encoded. Default is '.'"@en;
+            rdfs:subPropertyOf owl:topDataProperty ;
+            rdfs:domain cx-fx:Function ;
+            rdfs:range xsd:string;
+            skos:example ".";
+            skos:altLabel "Function Input Property"@en;
+            skos:prefLabel "Input Property"@en .
+
+###  https://w3id.org/catenax/ontology/function#invocationIdProperty
+cx-fx:invocationIdProperty rdf:type owl:DatatypeProperty ;
+            rdfs:comment "Determines a (set of) paths in the input document under which the IRI of the invocation (instance of Function) will be transmitted."@en;
+            rdfs:subPropertyOf owl:topDataProperty ;
+            rdfs:domain cx-fx:Function ;
+            rdfs:range xsd:string;
+            skos:example "requestId";
+            skos:altLabel "Function Invocation ID Property"@en;
+            skos:prefLabel "Invocation ID Property"@en .
+
+###  https://w3id.org/catenax/ontology/function#callbackProperty
+cx-fx:callbackProperty rdf:type owl:DatatypeProperty ;
+            rdfs:comment "Determines a (set of) paths in the input document and the output response under which the callback address (see <https://w3id.org/catenax/ontology/function#callbackAddress>) and the referring callback id will be transmitted."@en;
+            rdfs:subPropertyOf owl:topDataProperty ;
+            rdfs:domain cx-fx:Function ;
+            rdfs:domain cx-fx:Result ;
+            rdfs:range xsd:string;
+            skos:example "callbackAddress";
+            skos:altLabel "Function Callback ID/Address Property"@en;
+            skos:prefLabel "Callback Address"@en .
+
+###  https://w3id.org/catenax/ontology/function#input
+cx-fx:input rdf:type owl:ObjectProperty ;
+            rdfs:domain cx-fx:Function ;
+            rdfs:range cx-fx:Argument;
+            rdfs:comment  "Describes the arguments of a function."@en ;
+            skos:prefLabel "Input Argument"@en .
+
+###  https://w3id.org/catenax/ontology/function#input
+cx-fx:result rdf:type owl:ObjectProperty ;
+            rdfs:domain cx-fx:Function ;
+            rdfs:range cx-fx:Result;
+            rdfs:comment  "Describes the result of a function."@en ;
+            skos:prefLabel "Output Result"@en .
+
+###  https://w3id.org/catenax/ontology/function#Argument
+cx-fx:Argument rdf:type owl:Class ;
+               rdfs:subClassOf cx-core:ConceptualObject ;
+               skos:altLabel "Function Argument Definition"@en ;
+               skos:prefLabel "Argument"@en .
+
+###  https://w3id.org/catenax/ontology/function#Result
+cx-fx:Result rdf:type owl:Class ;
+             rdfs:subClassOf cx-core:ConceptualObject ;
+             skos:altLabel "Function Result Definition"@en ;
+             skos:prefLabel "Result"@en .
+
+
+###  https://w3id.org/catenax/ontology/function#argumentName
+cx-fx:argumentName rdf:type owl:DatatypeProperty ;
+            rdfs:comment "Determines the name or index of the function argument.";
+            rdfs:subPropertyOf owl:topDataProperty ;
+            rdfs:domain cx-fx:Argument ;
+            rdfs:range xsd:string;
+            skos:example "arg0";
+            skos:example "age";
+            skos:altLabel "Argument Name or Index"@en;
+            skos:prefLabel "Argument Name"@en .
+
+###  https://w3id.org/catenax/ontology/function#argumentName
+cx-fx:dataType rdf:type owl:DatatypeProperty ;
+               rdfs:comment "Determines the data type of an argument or return value.";
+               rdfs:subPropertyOf owl:topDataProperty ;
+               rdfs:domain cx-fx:Argument;
+               rdfs:domain cx-fx:ReturnValue ];
+               rdfs:range rdfs:Datatype;
+               skos:example json:Object;
+               skos:example xsd:long;
+               skos:altLabel "Argument or Result Data Type"@en;
+               skos:prefLabel "Argument or Result Data Type"@en .
+
+###  https://w3id.org/catenax/ontology/function#priority
+cx-fx:priority rdf:type owl:DatatypeProperty ;
+            rdfs:comment "Determines the priority with which the argument is processed. Default is '10'"@en;
+            rdfs:subPropertyOf owl:topDataProperty ;
+            rdfs:domain cx-fx:Argument ;
+            rdfs:range xsd:integer;
+            skos:example "-1"^^xsd:integer;
+            skos:altLabel "Argument Priority"@en;
+            skos:prefLabel "Priority"@en .
+
+###  https://w3id.org/catenax/ontology/function#default
+cx-fx:default rdf:type owl:DatatypeProperty ;
+            rdfs:comment "Determines a default for the given argument which is taken if this is a mandatory argument (see <https://w3id.org/catenax/ontology/function#mandatory>)"@en;
+            rdfs:subPropertyOf owl:topDataProperty ;
+            rdfs:domain cx-fx:Argument ;
+            rdfs:range xsd:anyType;
+            skos:example "a default string"^^xsd:string;
+            skos:example <urn:default:uri>;
+            skos:altLabel "Argument Default"@en;
+            skos:prefLabel "Default"@en .
+
+###  https://w3id.org/catenax/ontology/function#outputProperty
+cx-fx:outputProperty rdf:type owl:DatatypeProperty ;
+            rdfs:comment "Determines a path/name in the output response under which all output arguments are encoded. Default is '.'"@en;
+            rdfs:subPropertyOf owl:topDataProperty ;
+            rdfs:domain cx-fx:Result ;
+            rdfs:range xsd:string;
+            skos:example ".";
+            skos:altLabel "Function Output Property"@en;
+            skos:prefLabel "Output Property"@en .
+
+###  https://w3id.org/catenax/ontology/function#resultIdProperty
+cx-fx:resultIdProperty rdf:type owl:DatatypeProperty ;
+            rdfs:comment "Determines a path in the output response under which the IRI of the result component will be transmitted."@en;
+            rdfs:subPropertyOf owl:topDataProperty ;
+            rdfs:domain cx-fx:Result ;
+            rdfs:range xsd:string;
+            skos:example "componentId";
+            skos:altLabel "Function Result ID Property"@en;
+            skos:prefLabel "Result ID Property"@en .
+
+###  https://w3id.org/catenax/ontology/function#correlationInput
+cx-fx:correlationInput rdf:type owl:ObjectProperty ;
+            rdfs:comment "Correlates the <ttps://w3id.org/catenax/ontology/function#resultIdProperty> with a function argument."@en;
+            rdfs:domain cx-fx:Result ;
+            rdfs:range cx-fx:Argument;
+            skos:altLabel "Function Correlation ID Inputy"@en;
+            skos:prefLabel "Correlation ID Input"@en .
+
+###  https://w3id.org/catenax/ontology/function#output
+cx-fx:output rdf:type owl:ObjectProperty ;
+            rdfs:domain cx-fx:Result ;
+            rdfs:range cx-fx:ReturnValue;
+            skos:altLabel "Function Return Output"@en;
+            skos:prefLabel "Output"@en .
+
+###  https://w3id.org/catenax/ontology/function#ReturnValue
+cx-fx:ReturnValue rdf:type owl:Class ;
+             rdfs:subClassOf cx-core:ConceptualObject ;
+             skos:altLabel "Function Return Value Definition"@en ;
+             skos:prefLabel "Return Value"@en .
+
+###  https://w3id.org/catenax/ontology/function#valuePath
+cx-fx:valuePath rdf:type owl:DatatypeProperty ;
+            rdfs:comment "Determines a path in the output response under which a return value is transmitted."@en;
+            rdfs:subPropertyOf owl:topDataProperty ;
+            rdfs:domain cx-fx:ReturnValue ;
+            rdfs:range xsd:string;
+            skos:example "age";
+            skos:altLabel "Function Result Value Path"@en;
+            skos:prefLabel "Value Path"@en .
+
+###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi

--- a/ontology/reliability_ontology.ttl
+++ b/ontology/reliability_ontology.ttl
@@ -17,7 +17,9 @@
                                                  dc:creator "Zazralt Magic" ;
                                                  dc:date "2023-02-21"^^xsd:date ;
                                                  dc:title "Reliability Ontology"@en ;
-                                                 owl:versionInfo "0.0.1" .
+                                                 owl:imports <file:core_ontology.ttl>;
+                                                 owl:imports <file:vehicle_ontology.ttl>;
+                                                 owl:versionInfo "1.9.4" .
 
 #################################################################
 #    Annotation properties

--- a/ontology/vehicle_ontology.ttl
+++ b/ontology/vehicle_ontology.ttl
@@ -17,7 +17,8 @@
                                              dc:date "2023-02-21"^^xsd:date ;
                                              dc:description "Ontology for vehicles in the automotive industry." ;
                                              dc:title "Vehicle Ontology" ;
-                                             owl:versionInfo "0.0.1" .
+                                             owl:imports <file:core_ontology.ttl>;
+                                             owl:versionInfo "1.9.4" .
 
 #################################################################
 #    Annotation properties

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Pom for building complete product
+  See copyright notice in the top folder
+  See authors file in the top folder
+  See license file in the top folder
+-->
 <project>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.eclipse.tractusx</groupId>
+    <groupId>io.catenax</groupId>
     <artifactId>ontology</artifactId>
     <packaging>pom</packaging>
-    <version>1.9.1-SNAPSHOT</version>
-    <name>Tractus-X Knowledge Agents Ontology</name>
+    <version>1.9.4-SNAPSHOT</version>
+    <name>Catena-X Knowledge Agents Ontology</name>
     <description>Project for all Ontology-Related Artifacts</description>
     <dependencies>
     </dependencies>
@@ -21,15 +28,15 @@
         <!-- REPO -->
         <repo>ghcr.io/catenax-ng/product-ontology/</repo>
         <platform>linux/amd64</platform>
+
     </properties>
+
     <modules>
        <module>tools</module>
     </modules>
 
-
-
     <dependencyManagement>
-        <dependencies>
+      <dependencies>
             <!-- BOMs -->
             <dependency>
                 <groupId>org.junit</groupId>
@@ -43,7 +50,6 @@
 
     <build>
         <pluginManagement>
-
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -57,7 +63,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -150,6 +156,7 @@
     </build>
 
 
+
     <repositories>
         <repository>
             <id>central</id>
@@ -157,18 +164,17 @@
             <url>https://repo1.maven.org/maven2</url>
         </repository>
         <repository> <!-- webvowl -->
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
+		      <id>jitpack.io</id>
+		      <url>https://jitpack.io</url>
+	    </repository>
     </repositories>
 
-
     <distributionManagement>
-        <repository>
-            <id>github</id>
-            <name>Catena-X Maven Repository on Github</name>
-            <url>https://maven.pkg.github.com/catenax-ng/product-ontology</url>
-        </repository>
+     <repository>
+       <id>github</id>
+       <name>Catena-X Maven Repository on Github</name>
+       <url>https://maven.pkg.github.com/catenax-ng/product-ontology</url>
+     </repository>
     </distributionManagement>
 
 </project>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -3,13 +3,21 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+<<<<<<< Updated upstream
     <groupId>org.eclipse.tractusx.ontology</groupId>
     <artifactId>tools</artifactId>
 
     <parent>
       <groupId>org.eclipse.tractusx</groupId>
+=======
+    <groupId>io.catenax.ontology</groupId>
+    <artifactId>tools</artifactId>
+
+    <parent>
+      <groupId>io.catenax</groupId>
+>>>>>>> Stashed changes
       <artifactId>ontology</artifactId>
-      <version>1.9.1-SNAPSHOT</version>
+      <version>1.9.4-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -35,7 +43,7 @@
       <dependency>
          <groupId>net.sourceforge.owlapi</groupId>
          <artifactId>owlapi-distribution</artifactId>
-         <version>5.1.20</version>
+         <version>5.5.0</version>
       </dependency>
 
       <!-- special conversion for viz (stylesheet is too complicated ta the moment) -->
@@ -49,13 +57,13 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.7</version>
       </dependency>
 
     <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-nop</artifactId>
-        <version>1.7.36</version>
+        <version>2.0.7</version>
     </dependency> 
 
       <!-- logging -->
@@ -64,19 +72,19 @@
        <dependency>
 					<groupId>org.apache.logging.log4j</groupId>
 					 <artifactId>log4j-api</artifactId>
-					<version>2.17.1</version>
+					<version>2.20.0</version>
 				</dependency>
 
        <dependency>
 					<groupId>org.apache.logging.log4j</groupId>
 					 <artifactId>log4j-core</artifactId>
-					<version>2.17.1</version>
+					<version>2.20.0</version>
 				</dependency>
 
        <dependency>
 					<groupId>org.apache.logging.log4j</groupId>
 					 <artifactId>log4j-to-slf4j</artifactId>
-					<version>2.17.1</version>
+					<version>2.20.0</version>
 				</dependency>
 
       <!-- test framework -->

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -3,19 +3,11 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-<<<<<<< Updated upstream
-    <groupId>org.eclipse.tractusx.ontology</groupId>
-    <artifactId>tools</artifactId>
-
-    <parent>
-      <groupId>org.eclipse.tractusx</groupId>
-=======
     <groupId>io.catenax.ontology</groupId>
     <artifactId>tools</artifactId>
 
     <parent>
       <groupId>io.catenax</groupId>
->>>>>>> Stashed changes
       <artifactId>ontology</artifactId>
       <version>1.9.4-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>


### PR DESCRIPTION
## WHAT

Introduces the Function and Behaviour ontologies.

## WHY

Functions (or rather function invocations which result from performing SPARQL queries against accordingly defined graphs) are important for interfacing backend services via KA technology.

The behaviour (prediction) ontology is the first ontology making use of function definitions.

## FURTHER NOTES

Fixes some protege import problems when using local file version uris.
Adapt the merge tool to create a protege and rdf4j/jena compatible ontology.
