### PR TITLE
Add subtypes of cx-taxo:Asset

### DIFF
--- a/ontology/taxonomy.ttl
+++ b/ontology/taxonomy.ttl
@@ -19,19 +19,19 @@ cx-taxo:Thing a skos:Concept;
     skos:prefLabel "Ding"@de,
         "Thing"@en .
         
-        cx-taxo:PhysicalObject a skos:Concept ;
-            skos:broader cx-taxo:Thing ;
-            skos:prefLabel "Physical Object"@en ;
+cx-taxo:PhysicalObject a skos:Concept ;
+    skos:broader cx-taxo:Thing ;
+    skos:prefLabel "Physical Object"@en ;
         .
         
-        cx-taxo:ConceptionalObject a skos:Concept ;
-            skos:broader cx-taxo:Thing ;
-            skos:prefLabel "Conceptional Object"@en.
+cx-taxo:ConceptionalObject a skos:Concept ;
+    skos:broader cx-taxo:Thing ;
+    skos:prefLabel "Conceptional Object"@en.
             
-            cx-taxo::Asset a skos:Concept ;
-                skos:broader cx-taxo:ConceptionalObject ;
-                skos:prefLabel "Asset"@en ;
-                skos:definition "The Asset concept describes the provision via a repository of a specific set of data for a specific purpose"@en .
+cx-taxo::Asset a skos:Concept ;
+    skos:broader cx-taxo:ConceptionalObject ;
+    skos:prefLabel "Asset"@en ;
+    skos:definition "The Asset concept describes the provision via a repository of a specific set of data for a specific purpose"@en .
 
 cx-taxo:Additive a skos:Concept ;
     rdfs:seeAlso wiki-en:Q350176 ;
@@ -371,8 +371,6 @@ cx-taxo:ChemicalDispersion a skos:Concept ;
     skos:prefLabel "Dispersion"@de,
         "Chemical Dispersion"@en .
 
-
-
 cx-taxo:Substance a skos:Concept ;
     rdfs:seeAlso wiki-en:Substance ;
     skos:broader cx-taxo:MaterialThing ;
@@ -466,10 +464,10 @@ cx-taxo:Actor a skos:Concept ;
     skos:prefLabel "Actor"@de,
         "Actor"@en .
         
-        cx-taxo:Company a skos:Concept ;
-            skos:broader cx-taxo:Actor ;
-            skos:prefLabel "Company"@en,
-             "Unternhemen"@de.
+cx-taxo:Company a skos:Concept ;
+    skos:broader cx-taxo:Actor ;
+    skos:prefLabel "Company"@en,
+        "Unternhemen"@de.
 
 cx-taxo:InformationObject a skos:Concept ;
     skos:broader  cx-taxo:ConceptionalObject;

--- a/ontology/taxonomy.ttl
+++ b/ontology/taxonomy.ttl
@@ -28,10 +28,21 @@ cx-taxo:ConceptionalObject a skos:Concept ;
     skos:broader cx-taxo:Thing ;
     skos:prefLabel "Conceptional Object"@en.
             
-cx-taxo::Asset a skos:Concept ;
+cx-taxo:Asset a skos:Concept ;
     skos:broader cx-taxo:ConceptionalObject ;
     skos:prefLabel "Asset"@en ;
     skos:definition "The Asset concept describes the provision via a repository of a specific set of data for a specific purpose"@en .
+
+cx-taxo:DigitalTwinRegistry a skos:Concept;
+    skos:broader cx-taxo:Asset;
+    skos:prefLabel "Digital Twin Registry";
+    skos:definition "The Digital Twin Registry (DTR) is the union of the Catena-X-selected subsets of the Asset Administration Shell Registry and Discovery APIs."
+    skos:example "https://github.com/eclipse-tractusx/sldt-digital-twin-registry"
+
+cx-taxo:Submodel a skos:Concept;
+    skos:broader cx-taxo:Asset;
+    skos:prefLabel "Submodel";
+    skos:definition "The Submodel API serves aspects of a Digital Twin according to the Asset Administration Shell standard."
 
 cx-taxo:Additive a skos:Concept ;
     rdfs:seeAlso wiki-en:Q350176 ;
@@ -43,7 +54,6 @@ cx-taxo:Additive a skos:Concept ;
     skos:example "lubricant"@en ;
     skos:prefLabel "Additiv"@de,
         "Additive"@en .
-
 
 cx-taxo:Aerosol a skos:Concept ;
     rdfs:seeAlso wiki-en:Aerosol ;

--- a/ontology/taxonomy.ttl
+++ b/ontology/taxonomy.ttl
@@ -31,7 +31,7 @@ cx-taxo:ConceptionalObject a skos:Concept ;
 cx-taxo:Asset a skos:Concept ;
     skos:broader cx-taxo:ConceptionalObject ;
     skos:prefLabel "Asset"@en ;
-    skos:definition "The Asset concept describes the provision via a repository of a specific set of data for a specific purpose"@en .
+    skos:definition "The Asset concept describes the provision via a repository of a specific set of data for a specific purpose. It is defined by its public API."@en .
 
 cx-taxo:DigitalTwinRegistry a skos:Concept;
     skos:broader cx-taxo:Asset;
@@ -43,6 +43,41 @@ cx-taxo:Submodel a skos:Concept;
     skos:broader cx-taxo:Asset;
     skos:prefLabel "Submodel";
     skos:definition "The Submodel API serves aspects of a Digital Twin according to the Asset Administration Shell standard."
+
+cx-taxo:ReceiveQualityInvestigationNotification a skos:Concept;
+    skos:broader cx-taxo:Asset;
+    skos:prefLabel "Receive Quality Investigation Notification";
+    skos:definition "API to receive quality investigation notifications"
+
+cx-taxo:ReceiveQualityAlertNotification a skos:Concept;
+    skos:broader cx-taxo:Asset;
+    skos:prefLabel "Receive Quality Alert Notification";
+    skos:definition "API to receive quality alert notifications"
+
+cx-taxo:UpdateQualityInvestigationNotification a skos:Concept;
+    skos:broader cx-taxo:Asset;
+    skos:prefLabel "Update Quality Investigation Notification";
+    skos:definition "API to update quality investigation notifications"
+
+cx-taxo:UpdateQualityAlertNotification a skos:Concept;
+    skos:broader cx-taxo:Asset;
+    skos:prefLabel "Update Quality Alert Notification";
+    skos:definition "API to update quality Alert notifications"
+
+cx-taxo:ResolveQualityInvestigationNotification a skos:Concept;
+    skos:broader cx-taxo:Asset;
+    skos:prefLabel "Resolve Quality Investigation Notification";
+    skos:definition "API to update quality investigation notifications"
+
+cx-taxo:ResolveQualityAlertNotification a skos:Concept;
+    skos:broader cx-taxo:Asset;
+    skos:prefLabel "Resolve Quality Alert Notification";
+    skos:definition "API to resolve quality Alert notifications"
+
+cx-taxo:PcfExchange a skos:Concept;
+    skos:broader cx-taxo:Asset;
+    skos:prefLabel "PCF Exchange API";
+    skos:definition "API to exchange data on Product Carbon Footprints"
 
 cx-taxo:Additive a skos:Concept ;
     rdfs:seeAlso wiki-en:Q350176 ;


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Catena-X Association
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

This introduces subtypes of EDC Data Assets for the Digital Twin, Traceability and CO2 domain.

## WHY

These are the first taxonomy entries for unified querying of EDC Catalogs.


