### PR TITLE
add quality asset

### DIFF
--- a/taxonomy.ttl
+++ b/taxonomy.ttl
@@ -861,6 +861,11 @@ cx-taxo:Thing a skos:Concept;
                 skos:prefLabel "Skill Asset"@en ;
                 skos:definition "This subconcept of Asset allows only the execution of predefined data queries on assets."@en .
 
+            cx-taxo:QualityAsset a skos:Concept ;
+                skos:broader cx-taxo:Asset ;
+                skos:prefLabel "Quality Asset"@en ;
+                skos:definition "This subconcept of Asset signifies that a data offer is associated with the Quality use-case. Assets and data offers are further specified by the dcat:conformsTo property."@en .
+
             
             cx-taxo:FuelType a skos:Concept ;
                 skos:broader cx-taxo:ConceptionalObject ;


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Catena-X Association
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

add quality asset as defined in 
https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/pull/567

## WHY

Quality Assets must (like all) be typed via a property pointing to this controlled vocabulary.

