### PR TITLE
feat: add dcm assets to taxonomy

### DIFF
--- a/taxonomy.ttl
+++ b/taxonomy.ttl
@@ -851,10 +851,10 @@ cx-taxo:Thing a skos:Concept;
                 skos:prefLabel "PCF Exchange API"@en;
                 skos:definition "API to exchange data on Product Carbon Footprints".
 
-             cx-taxo:GraphAsset a skos:Concept ;
-                    skos:broader cx-taxo:Asset ;
-                    skos:prefLabel "Graph Asset"@en ;
-                    skos:definition "This subconcept of Asset allows arbitrary data queries to be executed on assets."@en .
+            cx-taxo:GraphAsset a skos:Concept ;
+                skos:broader cx-taxo:Asset ;
+                skos:prefLabel "Graph Asset"@en ;
+                skos:definition "This subconcept of Asset allows arbitrary data queries to be executed on assets."@en .
                 
             cx-taxo:SkillAsset a skos:Concept ;
                 skos:broader cx-taxo:Asset ;
@@ -866,7 +866,26 @@ cx-taxo:Thing a skos:Concept;
                 skos:prefLabel "Quality Asset"@en ;
                 skos:definition "This subconcept of Asset signifies that a data offer is associated with the Quality use-case. Assets and data offers are further specified by the dcat:conformsTo property."@en .
 
-            
+            cx-taxo:DcmMaterialDemand a skos:Concept;
+                skos:broader cx-taxo:Asset;
+                skos:prefLabel "Receive Material Demand DCM"@en;
+                skos:definition "API to receive a Material Demand in DCM context".
+
+            cx-taxo:DcmWeekBasedCapacityGroup a skos:Concept;
+                skos:broader cx-taxo:Asset;
+                skos:prefLabel "Receive Week Based Capacity Group DCM"@en;
+                skos:definition "API to receive a Week Based Capacity Group in DCM context".
+
+            cx-taxo:DcmIdBasedRequestForUpdate a skos:Concept;
+                skos:broader cx-taxo:Asset;
+                skos:prefLabel "Receive ID Based Request for Update DCM"@en;
+                skos:definition "API to receive an ID Based Request for Update in DCM context".
+
+            cx-taxo:DcmIdBasedComment a skos:Concept;
+                skos:broader cx-taxo:Asset;
+                skos:prefLabel "Receive ID Based Comment for DCM"@en;
+                skos:definition "API to receive an ID Based Comment in DCM context".
+
             cx-taxo:FuelType a skos:Concept ;
                 skos:broader cx-taxo:ConceptionalObject ;
                 rdfs:seeAlso <https://de.wikipedia.org/wiki/Kraftstoffcode>,


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Catena-X Association
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

Adds four dcm asset types.

## WHY

URIs mentioned in the standard but not yet in here.
