### PR TITLE
Add DCM DcmWeekBasedMaterialDemand asset

### DIFF
--- a/taxonomy.ttl
+++ b/taxonomy.ttl
@@ -871,6 +871,11 @@ cx-taxo:Thing a skos:Concept;
                 skos:prefLabel "Receive Material Demand DCM"@en;
                 skos:definition "API to receive a Material Demand in DCM context".
 
+            cx-taxo:DcmWeekBasedMaterialDemand a skos:Concept;
+                skos:broader cx-taxo:Asset;
+                skos:prefLabel "Receive Week Based Material Demand DCM"@en;
+                skos:definition "API to receive a Week Based Material Demand in DCM context".
+
             cx-taxo:DcmWeekBasedCapacityGroup a skos:Concept;
                 skos:broader cx-taxo:Asset;
                 skos:prefLabel "Receive Week Based Capacity Group DCM"@en;


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Catena-X Association
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

_Briefly describe what your PR changes, which features it adds/modifies._

Add DCM DcmWeekBasedMaterialDemand asset to taxonomy

## WHY

_Briefly state why the change was necessary._

To be up to date with DCM 24.05 standard

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
