### PR TITLE
Update taxonomy entries or Unique ID Push notifications of Industry Core for Release 24.05

### DIFF
--- a/taxonomy.ttl
+++ b/taxonomy.ttl
@@ -846,6 +846,16 @@ cx-taxo:Thing a skos:Concept;
                 skos:prefLabel "Receive Unique ID Push Notification"@en;
                 skos:definition "API to receive Unique Id Push notifications".
 
+            cx-taxo:UniqueIdPushConnectToParentNotification a skos:Concept;
+                skos:broader cx-taxo:Asset;
+                 skos:prefLabel "Unique ID Push Connect-to-Parent Notification"@en;
+                skos:definition "API to receive a Unique ID Push notification to connect a digital twin with its parent digital twin (bottom-up notification)".
+
+            cx-taxo:UniqueIdPushConnectToChildNotification a skos:Concept;
+                skos:broader cx-taxo:Asset;
+                 skos:prefLabel "Unique ID Push Connect-to-Child Notification"@en;
+                skos:definition "API to receive a Unique ID Push notification to connect a digital twin with its child digital twin (top-down notification)".
+
             cx-taxo:PcfExchange a skos:Concept;
                 skos:broader cx-taxo:Asset;
                 skos:prefLabel "PCF Exchange API"@en;


### PR DESCRIPTION
### WHAT

Add new taxonomy entries for classification of Unique ID Push notifications API assets

### WHY

With release 24.05, the Unique ID Push notification API is updated for the Industry Core KIT. To correctly classify the Connector assets required for publishing this API to Catena-X, new taxonomy entries are required.